### PR TITLE
Support objects that return valid URI strings through to_s

### DIFF
--- a/lib/pact/consumer_contract/pact_file.rb
+++ b/lib/pact/consumer_contract/pact_file.rb
@@ -5,9 +5,9 @@ module Pact
     extend self
 
     def read uri, options = {}
-      pact = open(uri) { | file | file.read }
+      pact = open(uri.to_s) { | file | file.read }
       if options[:save_pactfile_to_tmp]
-        save_pactfile_to_tmp pact, ::File.basename(uri)
+        save_pactfile_to_tmp pact, ::File.basename(uri.to_s)
       end
       pact
     rescue StandardError => e


### PR DESCRIPTION
We currently have an implementation that allows Pact to open S3 files natively by using a file decorator which implements `open`.

This change allows Pact to use any object that implements the interface, not just a URI object.
