### PR TITLE
Fix bug in calling of SomethingLike serialisation

### DIFF
--- a/lib/pact/something_like.rb
+++ b/lib/pact/something_like.rb
@@ -20,7 +20,7 @@ module Pact
       }
     end
 
-    def as_json
+    def as_json opts = {}
       to_hash
     end
 


### PR DESCRIPTION
When using SomethingLike in the body of the answer, there is a code creash. This fixes it.

No code spec demonstrating the issue, I did not figure out where these go. 
My sample is a high level one: 
      .will_respond_with(
          status: 200
          body: ({ login: "ok",
                  stuff: Pact::SomethingLike.new(10), #Pact::Term.new(generate: '10', matcher: /\d+/),
            }))
