### PR TITLE
Add response matching rules to the interaction view

### DIFF
--- a/lib/pact/doc/interaction_view_model.rb
+++ b/lib/pact/doc/interaction_view_model.rb
@@ -96,7 +96,7 @@ module Pact
       end
 
       def ordered_keys
-        [:method, :path, :query, :status, :headers, :body]
+        [:method, :path, :query, :status, :headers, :body, :matchingRules]
       end
 
       def remove_key_if_empty key, hash

--- a/spec/lib/pact/doc/interaction_view_model_spec.rb
+++ b/spec/lib/pact/doc/interaction_view_model_spec.rb
@@ -9,8 +9,8 @@ module Pact
 
       let(:interaction_with_request_with_body_and_headers) { consumer_contract.find_interaction description: "a request with a body and headers" }
       let(:interaction_with_request_without_body_and_headers) { consumer_contract.find_interaction description: "a request with an empty body and empty headers" }
-      let(:interaction_with_response_with_body_and_headers) { consumer_contract.find_interaction description: "a response with a body and headers" }
-      let(:interaction_with_response_without_body_and_headers) { consumer_contract.find_interaction description: "a response with an empty body and empty headers" }
+      let(:interaction_with_response_with_body_matchers_and_headers) { consumer_contract.find_interaction description: "a response with a body, matchers and headers" }
+      let(:interaction_with_response_without_body_matchers_and_headers) { consumer_contract.find_interaction description: "a response with an empty body, matchers and empty headers" }
 
       let(:interaction) { consumer_contract.interactions.first }
 
@@ -83,6 +83,7 @@ module Pact
             expect(subject.request).to include("body")
           end
         end
+
         context "when the headers hash is empty" do
 
           let(:interaction) { interaction_with_request_without_body_and_headers }
@@ -105,7 +106,7 @@ module Pact
 
       describe "response" do
 
-        let(:interaction) { interaction_with_response_with_body_and_headers }
+        let(:interaction) { interaction_with_response_with_body_matchers_and_headers }
 
         it "includes the status" do
           expect(subject.response).to include('"status"')
@@ -115,27 +116,42 @@ module Pact
           expect(subject.response).to include('"body"')
           expect(subject.response).to include('"a body"')
         end
+
+        it "includes the matchers" do
+          expect(subject.response).to include('"matchingRules"')
+          expect(subject.response).to include('"$.body.key"')
+        end
+
         it "includes the headers" do
           expect(subject.response).to include('"headers"')
           expect(subject.response).to include('"a header"')
         end
 
         it "renders the keys in a meaningful order" do
-          expect(subject.response).to match /"status".*"headers".*"body"/m
+          expect(subject.response).to match /"status".*"headers".*"body".*"matchingRules"/m
         end
 
         context "when the body hash is empty" do
 
-          let(:interaction) { interaction_with_response_without_body_and_headers }
+          let(:interaction) { interaction_with_response_without_body_matchers_and_headers }
 
           it "does not include the body" do
             expect(subject.response).to_not include("body")
           end
         end
 
+        context "when the matchers hash is empty" do
+
+          let(:interaction) { interaction_with_response_without_body_matchers_and_headers }
+
+          it "does not include the matchers" do
+            expect(subject.response).to_not include("matchers")
+          end
+        end
+
         context "when the headers hash is empty" do
 
-          let(:interaction) { interaction_with_response_without_body_and_headers }
+          let(:interaction) { interaction_with_response_without_body_matchers_and_headers }
 
           it "does not include the headers" do
             expect(subject.response).to_not include("headers")

--- a/spec/support/interaction_view_model.json
+++ b/spec/support/interaction_view_model.json
@@ -32,7 +32,7 @@
             "response": {}
         },
         {
-            "description": "a response with a body and headers",
+            "description": "a response with a body, matchers and headers",
             "request": {
                 "method": "get",
                 "path": "/"
@@ -44,11 +44,16 @@
                 "body": {
                     "key": "a body"
                 },
+                "matchingRules": {
+                  "$.body.key": {
+                    "match": "type"
+                  }
+                },
                 "status": 200
             }
         },
         {
-            "description": "a response with an empty body and empty headers",
+            "description": "a response with an empty body, matchers and empty headers",
             "request": {
                 "method": "get",
                 "path": "/"
@@ -56,7 +61,8 @@
             "response": {
                 "status": 200,
                 "headers": {},
-                "body": {}
+                "body": {},
+                "matchingRules": {}
             }
         }
     ]


### PR DESCRIPTION
See discussion here: https://github.com/bethesque/pact_broker/issues/72

I also attempted to add matching rules to the request object, however it seems to be unsupported. I wasn't 100% sure where this support needs to be added. I think it's here, but didn't want to complicate things too much: https://github.com/bethesque/pact-support/blob/master/lib/pact/shared/request.rb

CC @bethesque 