### PR TITLE
fix(message): message body content should be 'contents'

### DIFF
--- a/lib/pact/provider/rspec.rb
+++ b/lib/pact/provider/rspec.rb
@@ -108,7 +108,7 @@ module Pact
           include Pact::RSpec::Matchers
           extend Pact::Matchers::Messages
 
-          let(:expected_content) { expected_response.body[:content].as_json }
+          let(:expected_content) { expected_response.body[:contents].as_json }
           let(:response) { interaction_context.last_response }
           let(:differ) { Pact.configuration.body_differ_for_content_type diff_content_type }
           let(:diff_formatter) { Pact.configuration.diff_formatter_for_content_type diff_content_type }


### PR DESCRIPTION
Spotted this, which is preventing verification from working correctly on a v3 message pact.