### PR TITLE
docs(readme): mention SPEC_OPTS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ At this stage, you'll want to be able to run your specs one at a time while you 
 
     $ rake pact:verify PACT_DESCRIPTION="a request for an alligator" PACT_PROVIDER_STATE="an alligator exists"
 
+This triggers all RSpec examples for interactions which match given description and provider state. You can also pass in RSpec options with `SPEC_OPTS`. For instance, if you'd like to run only the examples which check response body:
+
+    $ rake pact:verify SPEC_OPTS="--example has_a_matching_body"
+
 #### 4. Implement enough to make your first interaction spec pass
 
 Rinse and repeat.


### PR DESCRIPTION
I was trying to run a single example for a single interaction (as opposed to running the three generated ones) and couldn't find how to do it. I've found in the code that it is possible passing in any RSpec options through the `SPEC_OPTS` envar, so I though it'd be worth documenting this somewhere.