### PR TITLE
Fix quotes in code snippet

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -101,7 +101,7 @@ end
 
 ```ruby
 Pact.configure do | config |
-  config.pact_dir = `./spec/pacts`
+  config.pact_dir = './spec/pacts'
 end
 ```
 


### PR DESCRIPTION
Change back-ticks to straight (single) quotes to make the code snippet correct.