### PR TITLE
fix: ConsumerContractBuilder exposing incorrect field

### DIFF
--- a/lib/pact/consumer/consumer_contract_builder.rb
+++ b/lib/pact/consumer/consumer_contract_builder.rb
@@ -15,7 +15,7 @@ module Pact
 
       def initialize(attributes)
         @interaction_builder = nil
-        @consumer_contract_details = {
+        @consumer_contract = {
           consumer: {name: attributes[:consumer_name]},
           provider: {name: attributes[:provider_name]},
           pactfile_write_mode: attributes[:pactfile_write_mode].to_s,
@@ -42,7 +42,7 @@ module Pact
       end
 
       def write_pact
-        mock_service_client.write_pact @consumer_contract_details
+        mock_service_client.write_pact @consumer_contract
       end
 
       def wait_for_interactions options = {}

--- a/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
+++ b/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
@@ -62,6 +62,17 @@ module Pact
         end
       end
 
+      describe "#consumer_contract" do
+        it "returns the consumer contract" do
+      		expect(subject.consumer_contract).to eq(
+            consumer: { name: consumer_name },
+            provider: { name: provider_name },
+            pactfile_write_mode: 'overwrite',
+            pact_dir: pact_dir
+          )
+      	end
+      end
+
       describe "#mock_service_base_url" do
 
       	subject do


### PR DESCRIPTION
I believe `ConsumerContractBuilder` is trying to expose `attr_reader :consumer_contract`, but it's incorrectly setting that value to `@consumer_contract_details` instead. `@consumer_contract_details` is never used outside of this class.

This PR populates `@consumer_contract` instead of `@consumer_contract_details`.