### PR TITLE
Revert "Fix link to Ron Holshausen's blog post"

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Currently, Ruby Pact supports writing Pacts in v2, and verifying Pacts in v3 for
 
 ## Links
 
-[Simplifying microservices testing with pacts](http://dius.com.au/2014/05/20/simplifying-micro-service-testing-with-pacts/) - Ron Holshausen (one of the original pact authors)
+[Simplifying microservices testing with pacts](http://dius.com.au/2014/05/19/simplifying-micro-service-testing-with-pacts/) - Ron Holshausen (one of the original pact authors)
 
 [Pact specification](https://github.com/pact-foundation/pact-specification)
 


### PR DESCRIPTION
Reverts pact-foundation/pact-ruby#126 — after a long time I checked the link again, and apparently the blog owner has updated the dates, so now the old link is working again.