### PR TITLE
Add 'test' dir to pact_helper_locator file patterns

### DIFF
--- a/lib/pact/provider/pact_helper_locator.rb
+++ b/lib/pact/provider/pact_helper_locator.rb
@@ -1,21 +1,24 @@
 module Pact
   module Provider
     module PactHelperLocater
-        PACT_HELPER_FILE_PATTERNS = [
+      PACT_HELPER_FILE_PATTERNS = [
         "spec/**/*service*consumer*/pact_helper.rb",
         "spec/**/*consumer*/pact_helper.rb",
         "spec/**/pact_helper.rb",
-        "**/pact_helper.rb"]
+        "test/**/*service*consumer*/pact_helper.rb",
+        "test/**/*consumer*/pact_helper.rb",
+        "test/**/pact_helper.rb",
+        "**/pact_helper.rb"
+      ]
 
-        NO_PACT_HELPER_FOUND_MSG = "Please create a pact_helper.rb file that can be found using one of the following patterns: #{PACT_HELPER_FILE_PATTERNS.join(", ")}"
+      NO_PACT_HELPER_FOUND_MSG = "Please create a pact_helper.rb file that can be found using one of the following patterns: #{PACT_HELPER_FILE_PATTERNS.join(", ")}"
 
-        def self.pact_helper_path
-          pact_helper_search_results = []
-          PACT_HELPER_FILE_PATTERNS.find { | pattern | (pact_helper_search_results.concat(Dir.glob(pattern))).any? }
-          raise NO_PACT_HELPER_FOUND_MSG if pact_helper_search_results.empty?
-          File.join(Dir.pwd, pact_helper_search_results[0])
-        end
-
+      def self.pact_helper_path
+        pact_helper_search_results = []
+        PACT_HELPER_FILE_PATTERNS.find { | pattern | (pact_helper_search_results.concat(Dir.glob(pattern))).any? }
+        raise NO_PACT_HELPER_FOUND_MSG if pact_helper_search_results.empty?
+        File.join(Dir.pwd, pact_helper_search_results[0])
+      end
     end
   end
 end

--- a/spec/lib/pact/provider/pact_helper_locator_spec.rb
+++ b/spec/lib/pact/provider/pact_helper_locator_spec.rb
@@ -20,6 +20,12 @@ module Pact::Provider
         '/spec/serviceconsumers',
         '/spec/consumer',
         '/spec',
+        '/test/blah/service-consumers',
+        '/test/consumers',
+        '/test/blah/service_consumers',
+        '/test/serviceconsumers',
+        '/test/consumer',
+        '/test',
         '/blah',
         '/blah/consumer',
         ''


### PR DESCRIPTION
For us Minitest users, the lack of `test/...` paths in `PACT_HELPER_FILE_PATTERNS` causes `PactHelperLocator` to locate [this pact_helper.rb of the pact_broker-client](https://github.com/pact-foundation/pact_broker-client/blob/master/spec/service_providers/pact_helper.rb) before the actual `pact_helper.rb` file inside the `test` dir. 😨 