### PR TITLE
chore: update gemspec

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pact/version'
 
@@ -15,21 +14,21 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.0'
 
   gem.files         = `git ls-files bin lib pact.gemspec CHANGELOG.md LICENSE.txt`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
   gem.metadata = {
+    'changelog_uri'     => 'https://github.com/pact-foundation/pact-ruby/blob/master/CHANGELOG.md',
     'source_code_uri'   => 'https://github.com/pact-foundation/pact-ruby',
     'bug_tracker_uri'   => 'https://github.com/pact-foundation/pact-ruby/issues',
     'documentation_uri' => 'https://github.com/pact-foundation/pact-ruby/blob/master/README.md'
   }
 
-  gem.add_runtime_dependency 'rspec', '>=2.14'
+  gem.add_runtime_dependency 'rspec', '>= 2.14'
   gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 2.0.0'
   gem.add_runtime_dependency 'thor'
-  gem.add_runtime_dependency 'json','> 1.8.5'
   gem.add_runtime_dependency 'webrick'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
 
@@ -38,7 +37,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 3.0'
-  #gem.add_development_dependency 'pry-byebug'
+  gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'fakefs', '0.5' # 0.6.0 blows up
   gem.add_development_dependency 'hashie', '~> 2.0'
   gem.add_development_dependency 'activesupport'


### PR DESCRIPTION
* Drop unnecessary encoding pragma
* Use short form `__dir__`
* Add changelog
* Drop unnecessary `json` requirement
* Require `pry-byebug` for development