### PR TITLE
feat(generators): Pass context and add ProviderState generator

### DIFF
--- a/lib/pact/provider/generators.rb
+++ b/lib/pact/provider/generators.rb
@@ -1,0 +1,26 @@
+
+require 'pact/provider/generators/provider_state';
+
+module Pact
+  module Provider  
+    class Generators
+      def self.add_generator generator
+        generators.unshift(generator)
+      end
+
+      def self.generators
+        @generators ||= []
+      end
+
+      def self.execute_generators object, interaction_context = nil
+        generators.each do | parser |
+          return parser.call(object, interaction_context) if parser.can_generate?(object)
+        end
+        
+        raise Pact::UnrecognizePactFormatError.new("This document does not use a recognised Pact generator: #{object}")
+      end
+
+      add_generator(ProviderStateGenerator.new)
+    end
+  end
+end

--- a/lib/pact/provider/generators/provider_state.rb
+++ b/lib/pact/provider/generators/provider_state.rb
@@ -1,0 +1,58 @@
+require 'pact/provider/generators'
+
+module Pact
+  module Provider
+    class ProviderStateGenerator
+
+      
+      # rewrite of https://github.com/DiUS/pact-jvm/blob/master/core/support/src/main/kotlin/au/com/dius/pact/core/support/expressions/ExpressionParser.kt#L27
+      VALUES_SEPARATOR = ","
+      START_EXPRESSION = "\${"
+      END_EXPRESSION = '}'
+      def parse_expression expression, params 
+        
+        return_string = []
+
+        buffer = expression;
+        # initial value
+        position = buffer.index(START_EXPRESSION)
+        
+        while (position && position >= 0) 
+          if (position > 0) 
+            # add string 
+            return_string.push(buffer[0...position])
+          end
+          end_position = buffer.index(END_EXPRESSION, position)
+          if (end_position < 0)
+            raise "Missing closing brace in expression string \"#{$value}\""
+          end
+
+          variable = ""
+
+          if (end_position - position > 2)
+            expression = params[buffer[position+2...end_position]] || ""
+          end
+          return_string.push(expression)
+          
+          buffer = buffer[end_position + 1...-1]
+          position = buffer.index(START_EXPRESSION)
+        end
+
+        return_string.join("")
+      end
+
+      def call hash, interaction_context = nil
+        params = interaction_context.state_params || {}
+
+        parse_expression hash["expression"], params
+      end
+
+      def can_generate?(hash)
+        hash.key?('type') && hash['type'] === 'ProviderState'
+      end
+    end
+  end
+end
+
+
+

--- a/lib/pact/provider/request.rb
+++ b/lib/pact/provider/request.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'pact/reification'
 require 'pact/shared/null_expectation'
+require 'pact/provider/generators'
 
 module Pact
   module Provider
@@ -10,8 +11,9 @@ module Pact
         # See https://github.com/rack/rack/blob/e7d741c6282ca4cf4e01506f5681e6e6b14c0b32/SPEC#L87-89
         NO_HTTP_PREFIX = ["CONTENT-TYPE", "CONTENT-LENGTH"]
 
-        def initialize expected_request
+        def initialize expected_request, interaction_context = nil
           @expected_request = expected_request
+          @interaction_context = interaction_context
         end
 
         def method
@@ -19,6 +21,11 @@ module Pact
         end
 
         def path
+          if expected_request.methods.include? :generators
+            if expected_request.generators["path"]
+              return Pact::Provider::Generators.execute_generators(expected_request.generators["path"], @interaction_context)
+            end
+          end
           expected_request.full_path
         end
 

--- a/lib/pact/provider/test_methods.rb
+++ b/lib/pact/provider/test_methods.rb
@@ -14,8 +14,8 @@ module Pact
       include Pact::Logging
       include Rack::Test::Methods
 
-      def replay_interaction interaction, request_customizer = nil
-        request = Request::Replayable.new(interaction.request)
+      def replay_interaction interaction, request_customizer = nil, interaction_context
+        request = Request::Replayable.new(interaction.request, interaction_context)
         request = request_customizer.call(request, interaction) if request_customizer
         args = [request.path, request.body, request.headers]
 
@@ -36,11 +36,17 @@ module Pact
       end
 
       def set_up_provider_states provider_states, consumer, options = {}
+        state_params = {};
         # If there are no provider state, execute with an nil state to ensure global and base states are executed
         Pact.configuration.provider_state_set_up.call(nil, consumer, options) if provider_states.nil? || provider_states.empty?
         provider_states.each do | provider_state |
-          Pact.configuration.provider_state_set_up.call(provider_state.name, consumer, options.merge(params: provider_state.params))
+          result = Pact.configuration.provider_state_set_up.call(provider_state.name, consumer, options.merge(params: provider_state.params))
+          if result.is_a?(Hash)
+            state_params = state_params.merge(result)
+          end
         end
+
+        state_params
       end
 
       def tear_down_provider_states provider_states, consumer, options = {}


### PR DESCRIPTION
We want to parse and use **generators** in the contract to change a request validation according to the spec.

Reasoning and approach is described in pact-provider-verifier: https://github.com/pact-foundation/pact-provider-verifier/pull/53

Before this PR gets merged, I'd like to implement rest of generators [specification](https://github.com/pact-foundation/pact-specification/tree/version-3#introduce-example-generators) and add test coverage. 
