### PR TITLE
Set expected interactions on mock service without writing them to pact file

### DIFF
--- a/lib/pact/consumer/consumer_contract_builder.rb
+++ b/lib/pact/consumer/consumer_contract_builder.rb
@@ -25,6 +25,10 @@ module Pact
         @mock_service_base_url = "http://#{attributes[:host]}:#{attributes[:port]}"
       end
 
+      def without_writing_to_pact
+        interaction_builder.without_writing_to_pact
+      end
+
       def given(provider_state)
         interaction_builder.given(provider_state)
       end

--- a/lib/pact/consumer/interaction_builder.rb
+++ b/lib/pact/consumer/interaction_builder.rb
@@ -13,6 +13,12 @@ module Pact
         @callback = block
       end
 
+      def without_writing_to_pact
+        interaction.metadata ||= {}
+        interaction.metadata[:write_to_pact] = false
+        self
+      end
+
       def upon_receiving description
         @interaction.description = description
         self

--- a/spec/lib/pact/consumer/interaction_builder_spec.rb
+++ b/spec/lib/pact/consumer/interaction_builder_spec.rb
@@ -88,6 +88,21 @@ module Pact
           subject.will_respond_with response
         end
       end
+
+      describe "without_writing_to_pact" do
+        it "sets the write_to_pact key to false on metadata" do
+          mock_metadata = {}
+          expect(interaction).to receive(:metadata).and_return(nil, mock_metadata)
+          
+          subject.without_writing_to_pact
+
+          expect(mock_metadata).to eq({ write_to_pact: false })
+        end
+
+        it "returns itself" do
+          expect(subject.without_writing_to_pact).to be(subject)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This allows to call `without_writing_to_pact` when adding expectations to the mock service so that the interaction will have metadata with `write_to_pact: false` and the mock service will know to not write the interaction to the pact file.

```ruby
my_service
  .without_writing_to_pact # <= New
  .given('...')
  .upon_receiving('A request to..')
  .with(..)
  .will_respond_with(...)
```