### PR TITLE
feat: Add support for uris that are not strings

### DIFF
--- a/lib/pact/provider/pact_uri.rb
+++ b/lib/pact/provider/pact_uri.rb
@@ -29,10 +29,11 @@ module Pact
       end
 
       def to_s
-        if basic_auth? && uri.start_with?('http://', 'https://')
-          URI(@uri).tap { |x| x.userinfo="#{username}:*****"}.to_s
+        uri_string = uri.to_s
+        if basic_auth? && uri_string.start_with?('http://', 'https://')
+          URI(uri_string).tap { |x| x.userinfo="#{username}:*****"}.to_s
         else
-          uri
+          uri_string
         end
       end
     end

--- a/spec/lib/pact/provider/pact_uri_spec.rb
+++ b/spec/lib/pact/provider/pact_uri_spec.rb
@@ -47,5 +47,14 @@ describe Pact::Provider::PactURI do
         expect(pact_uri.to_s).to eq(uri)
       end
     end
+
+    context 'when uri is not a string' do
+      let(:uri) { double('uri', to_s: 'real_uri_to_s') }
+      let(:options) { {} }
+
+      it 'should return the to_s of the uri' do
+        expect(pact_uri.to_s).to eq('real_uri_to_s')
+      end
+    end
   end
 end


### PR DESCRIPTION
There are issues in the real world with uris being wrapped twice in pact
uris. When this happens the logging didn't work because of the
assumption that the uri value in pact_uri will always be a string. This
eliminates that assumption.