### PR TITLE
Update thor dependency

### DIFF
--- a/lib/pact/cli.rb
+++ b/lib/pact/cli.rb
@@ -4,6 +4,9 @@ require 'pact/provider/configuration'
 
 module Pact
   class CLI < Thor
+    def self.exit_on_failure? # Thor 1.0 deprecation guard
+      false
+    end
 
     desc 'verify', "Verify a pact"
     method_option :pact_helper, aliases: "-h", desc: "Pact helper file", :required => true

--- a/pact.gemspec
+++ b/pact.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'rspec', '~> 3.0'
   gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 2.0.0'
-  gem.add_runtime_dependency 'thor', '~> 0.20'
+  gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
 


### PR DESCRIPTION
Thor `1.0` is out, and we're using it with Pact on https://github.com/department-of-veterans-affairs/vets-api.

But we're having to maintain a fork to do so. This PR bumps the Thor dependency with a `< 2.0` max, imitating recent versions of Railties.

Feedback is welcome. Thank you!