### PR TITLE
Revert "fix: bump rake dependency per CVE-2020-8130"

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact-support', '~> 1.9'
   gem.add_runtime_dependency 'pact-mock_service', '~> 3.0', '>= 3.3.1'
 
-  gem.add_development_dependency 'rake', '>= 12.3.3'
+  gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'webmock', '~> 3.0'
   gem.add_development_dependency 'fakefs', '0.5' # 0.6.0 blows up
   gem.add_development_dependency 'hashie', '~> 2.0'


### PR DESCRIPTION
Reverts pact-foundation/pact-ruby#219