### PR TITLE
fix(security): hide personal access token given in uri

### DIFF
--- a/lib/pact/provider/pact_uri.rb
+++ b/lib/pact/provider/pact_uri.rb
@@ -17,7 +17,7 @@ module Pact
       end
 
       def basic_auth?
-        !!username
+        !!username && !!password
       end
 
       def username
@@ -29,12 +29,23 @@ module Pact
       end
 
       def to_s
-        if basic_auth? && uri.start_with?('http://', 'https://')
+        if basic_auth? && http_or_https_uri?
           URI(@uri).tap { |x| x.userinfo="#{username}:*****"}.to_s
+        elsif personal_access_token? && http_or_https_uri?
+          URI(@uri).tap { |x| x.userinfo="*****"}.to_s
         else
           uri
         end
       end
+
+      private def personal_access_token?
+        !!username && !password
+      end
+
+      private def http_or_https_uri?
+        uri.start_with?('http://', 'https://')
+      end
+      
     end
   end
 end

--- a/spec/lib/pact/provider/pact_uri_spec.rb
+++ b/spec/lib/pact/provider/pact_uri_spec.rb
@@ -23,15 +23,32 @@ describe Pact::Provider::PactURI do
   end
 
   describe '#to_s' do
-    context 'with userinfo provided' do
+    context 'with basic auth provided' do
       let(:password) { 'my_password' }
       let(:options) { { username: username, password: password } }
 
-      it 'should include user name and password' do
+      it 'should include user name and and hide password' do
         expect(pact_uri.to_s).to eq('http://pact:*****@uri')
       end
 
       context 'when basic auth credentials have been set for a local file (eg. via environment variables, unintentionally)' do
+        let(:uri) { '/some/file thing.json' }
+
+        it 'does not blow up' do
+          expect(pact_uri.to_s).to eq uri
+        end
+      end
+    end
+
+    context 'with personal access token provided' do
+      let(:pat) { 'should_be_secret' }
+      let(:options) { { username: pat } }
+
+      it 'should hide the pat' do
+        expect(pact_uri.to_s).to eq('http://*****@uri')
+      end
+
+      context 'when pat credentials have been set for a local file (eg. via environment variables, unintentionally)' do
         let(:uri) { '/some/file thing.json' }
 
         it 'does not blow up' do


### PR DESCRIPTION
Uris like https://pat@my-pact-server/pact.json are correct, where pat stands for personal access token, and is a secret.
=> the pat should not be exposed in logs [here ](https://github.com/pact-foundation/pact-ruby/blob/3cd57cb342ce17211edbb6c0c6ed5d36879cdbf9/lib/pact/provider/rspec.rb#L26)

It would be more elegant to not implictly consider the 'username' as 'pat' when there is no password, and maybe create another explicit property in the class, but i was not sure to control the impacts of such a change... (First commit ever in ruby :) ).
And after some digging arround, i'm not even sure it would worth it.

Please let me know if you think otherwise though.