### PR TITLE
fix: add consumer name to the selection description

### DIFF
--- a/lib/pact/pact_broker/pact_selection_description.rb
+++ b/lib/pact/pact_broker/pact_selection_description.rb
@@ -2,7 +2,6 @@ module Pact
   module PactBroker
     module PactSelectionDescription
       def pact_selection_description(provider, consumer_version_selectors, options, broker_base_url)
-        latest = consumer_version_selectors.any? ? "" : "latest "
         message = "Fetching pacts for #{provider} from #{broker_base_url} with the selection criteria: "
         if consumer_version_selectors.any?
           desc = consumer_version_selectors.collect do |selector|

--- a/lib/pact/pact_broker/pact_selection_description.rb
+++ b/lib/pact/pact_broker/pact_selection_description.rb
@@ -7,9 +7,10 @@ module Pact
         if consumer_version_selectors.any?
           desc = consumer_version_selectors.collect do |selector|
             all_or_latest = !selector[:latest] ? "all for tag" : "latest for tag"
+            consumer = selector[:consumer] ? "of consumer #{selector[:consumer]}" : nil
             fallback = selector[:fallback] || selector[:fallbackTag]
             name = fallback ? "#{selector[:tag]} (or #{fallback} if not found)" : selector[:tag]
-            "#{all_or_latest} #{name}"
+            [all_or_latest, name, consumer].compact.join(" ")
           end.join(", ")
           if options[:include_wip_pacts_since]
             desc = "#{desc}, work in progress pacts created after #{options[:include_wip_pacts_since]}"

--- a/spec/lib/pact/pact_broker/pact_selection_description_spec.rb
+++ b/spec/lib/pact/pact_broker/pact_selection_description_spec.rb
@@ -7,7 +7,7 @@ module Pact
 
       describe "#pact_selection_description" do
         let(:provider) { "Bar" }
-        let(:consumer_version_selectors) { [{ tag: "cmaster", latest: true, fallbackTag: "master"}, { tag: "prod"}] }
+        let(:consumer_version_selectors) { [{ tag: "cmaster", latest: true, fallbackTag: "master" }, { tag: "prod" }] }
         let(:options) do
           {
             include_wip_pacts_since: "2020-01-01"
@@ -18,6 +18,12 @@ module Pact
         subject { pact_selection_description(provider, consumer_version_selectors, options, broker_base_url) }
 
         it { is_expected.to eq "Fetching pacts for Bar from http://broker with the selection criteria: latest for tag cmaster (or master if not found), all for tag prod, work in progress pacts created after 2020-01-01" }
+
+        describe "when consumer selector specifies a consumer name" do
+          let(:consumer_version_selectors) { [{ tag: "cmaster", latest: true, consumer: "Foo" }] }
+
+          it { is_expected.to eq "Fetching pacts for Bar from http://broker with the selection criteria: latest for tag cmaster of consumer Foo, work in progress pacts created after 2020-01-01" }
+        end
       end
     end
   end


### PR DESCRIPTION
As described [here](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/#properties), we can fetch pacts filtering them by consumer name. When the `consumer_version_selectors` specifies a consumer name, there is no information about it in the pact fetching description so one can think it does not work.

Bonus: the `latest` variable was unused so I removed it. I'm wondering what was the idea behind it, maybe it should be used in the end?