### PR TITLE
feat: Provide configuration for build url to be published in verification results

### DIFF
--- a/lib/pact/provider/configuration/service_provider_config.rb
+++ b/lib/pact/provider/configuration/service_provider_config.rb
@@ -4,14 +4,15 @@ module Pact
       class ServiceProviderConfig
 
         attr_accessor :application_version
-        attr_reader :branch
+        attr_reader :branch, :build_url
 
-        def initialize application_version, branch, tags, publish_verification_results, &app_block
+        def initialize application_version, branch, tags, publish_verification_results, build_url, &app_block
           @application_version = application_version
           @branch = branch
           @tags = [*tags]
           @publish_verification_results = publish_verification_results
           @app_block = app_block
+          @build_url = build_url
         end
 
         def app

--- a/lib/pact/provider/configuration/service_provider_dsl.rb
+++ b/lib/pact/provider/configuration/service_provider_dsl.rb
@@ -15,7 +15,7 @@ module Pact
 
         extend Pact::DSL
 
-        attr_accessor :name, :app_block, :application_version, :branch, :tags, :publish_verification_results
+        attr_accessor :name, :app_block, :application_version, :branch, :tags, :publish_verification_results, :build_url
 
         CONFIG_RU_APP = lambda {
           unless File.exist? Pact.configuration.config_ru_path
@@ -46,6 +46,10 @@ module Pact
 
           def app_version_branch branch
             self.branch = branch
+          end
+
+          def build_url build_url
+            self.build_url = build_url
           end
 
           def publish_verification_results publish_verification_results
@@ -89,7 +93,7 @@ module Pact
         end
 
         def create_service_provider
-          Pact.configuration.provider = ServiceProviderConfig.new(application_version, branch, tags, publish_verification_results, &@app_block)
+          Pact.configuration.provider = ServiceProviderConfig.new(application_version, branch, tags, publish_verification_results, build_url, &@app_block)
         end
       end
     end

--- a/lib/pact/provider/verification_results/create.rb
+++ b/lib/pact/provider/verification_results/create.rb
@@ -14,7 +14,13 @@ module Pact
         end
 
         def call
-          VerificationResult.new(publishable?, !any_failures?, Pact.configuration.provider.application_version, test_results_hash_for_pact_uri)
+          VerificationResult.new(
+            publishable?,
+            !any_failures?,
+            Pact.configuration.provider.application_version,
+            test_results_hash_for_pact_uri,
+            Pact.configuration.provider.build_url
+          )
         end
 
         private

--- a/lib/pact/provider/verification_results/verification_result.rb
+++ b/lib/pact/provider/verification_results/verification_result.rb
@@ -6,11 +6,12 @@ module Pact
       class VerificationResult
         attr_reader :success, :provider_application_version, :test_results_hash
 
-        def initialize publishable, success, provider_application_version, test_results_hash
+        def initialize publishable, success, provider_application_version, test_results_hash, build_url
           @publishable = publishable
           @success = success
           @provider_application_version = provider_application_version
           @test_results_hash = test_results_hash
+          @build_url = build_url
         end
 
         def publishable?
@@ -25,7 +26,8 @@ module Pact
           {
             success: success,
             providerApplicationVersion: provider_application_version,
-            testResults: test_results_hash
+            testResults: test_results_hash,
+            buildUrl: @build_url
           }.to_json(options)
         end
 

--- a/spec/integration/publish_verification_spec.rb
+++ b/spec/integration/publish_verification_spec.rb
@@ -12,7 +12,8 @@ describe "publishing verifications" do
       application_version: '1.2.3',
       publish_verification_results?: true,
       branch: nil,
-      tags: [])
+      tags: [],
+      build_url: 'http://ci/build/1')
   end
 
   let(:pact_sources) do

--- a/spec/lib/pact/provider/configuration/service_provider_config_spec.rb
+++ b/spec/lib/pact/provider/configuration/service_provider_config_spec.rb
@@ -8,7 +8,7 @@ module Pact
 
           let(:app_block) { ->{ Object.new } }
 
-          subject { ServiceProviderConfig.new("1.2.3'", "main", [], true, &app_block) }
+          subject { ServiceProviderConfig.new("1.2.3'", "main", [], true, 'http://ci/build/1', &app_block) }
 
           it "should execute the app_block each time" do
             expect(subject.app.object_id).to_not equal(subject.app.object_id)

--- a/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
+++ b/spec/lib/pact/provider/configuration/service_provider_dsl_spec.rb
@@ -25,6 +25,19 @@ module Pact
             end
           end
 
+          context 'with build_url' do
+            subject(:config_build_url) { Pact.configuration.provider.build_url }
+            let(:ci_build_url) { 'http://ci/build/1' }
+
+            before do
+              ServiceProviderDSL.build 'name' do
+                build_url ci_build_url
+              end
+            end
+
+            it { is_expected.to eq(ci_build_url) }
+          end
+
         end
 
         describe "validate" do

--- a/spec/lib/pact/provider/verification_results/create_spec.rb
+++ b/spec/lib/pact/provider/verification_results/create_spec.rb
@@ -11,8 +11,9 @@ module Pact
 
         let(:verification_result) { double('VerificationResult') }
         let(:provider_configuration) do
-          double('provider_configuration', application_version: '1.2.3')
+          double('provider_configuration', application_version: '1.2.3', build_url: ci_build)
         end
+        let(:ci_build) { 'http://ci/build/1' }
         let(:pact_source_1) do
           instance_double('Pact::Provider::PactSource', uri: pact_uri_1, consumer_contract: consumer_contract)
         end
@@ -59,19 +60,25 @@ module Pact
               }
             }
           }
-          expect(VerificationResult).to receive(:new).with(anything, anything, anything, expected_test_results_hash)
+          expect(VerificationResult).to receive(:new).with(anything, anything, anything, expected_test_results_hash, anything)
           subject
         end
 
         it "creates a VerificationResult with the provider application version" do
           expect(provider_configuration).to receive(:application_version)
-          expect(VerificationResult).to receive(:new).with(anything, anything, '1.2.3', anything)
+          expect(VerificationResult).to receive(:new).with(anything, anything, '1.2.3', anything, anything)
+          subject
+        end
+
+        it "creates a VerificationResult with the provider ci build url" do
+          expect(provider_configuration).to receive(:build_url)
+          expect(VerificationResult).to receive(:new).with(anything, anything, anything, anything, ci_build)
           subject
         end
 
         context "when every interaction has been executed" do
           it "sets publishable to true" do
-            expect(VerificationResult).to receive(:new).with(true, anything, anything, anything)
+            expect(VerificationResult).to receive(:new).with(true, anything, anything, anything, anything)
             subject
           end
         end
@@ -81,14 +88,14 @@ module Pact
           let(:interactions) { [interaction_1, interaction_2]}
 
           it "sets publishable to false" do
-            expect(VerificationResult).to receive(:new).with(false, anything, anything, anything)
+            expect(VerificationResult).to receive(:new).with(false, anything, anything, anything, anything)
             subject
           end
         end
 
         context "when all the examples passed" do
           it "sets the success to true" do
-            expect(VerificationResult).to receive(:new).with(anything, true, anything, anything)
+            expect(VerificationResult).to receive(:new).with(anything, true, anything, anything, anything)
             subject
           end
         end
@@ -99,7 +106,7 @@ module Pact
           end
 
           it "sets the success to false" do
-            expect(VerificationResult).to receive(:new).with(anything, false, anything, anything)
+            expect(VerificationResult).to receive(:new).with(anything, false, anything, anything, anything)
             subject
           end
 


### PR DESCRIPTION
Thanks for the awesome project!

This PR adds a configuration option to add buildUrl into verification results, which could be added later as a [webhook param](https://github.com/pact-foundation/pact_broker/commit/17463b1664c2ae1949ad1c98021198160d598ef5) in pact broker. 