### PR TITLE
Fixup ruby warnings

### DIFF
--- a/lib/pact/provider/configuration/message_provider_dsl.rb
+++ b/lib/pact/provider/configuration/message_provider_dsl.rb
@@ -46,7 +46,7 @@ module Pact
           end
 
           def honours_pacts_from_pact_broker &block
-            create_pact_verification_from_broker &block
+            create_pact_verification_from_broker(&block)
           end
 
           def builder &block

--- a/lib/pact/provider/configuration/service_provider_dsl.rb
+++ b/lib/pact/provider/configuration/service_provider_dsl.rb
@@ -64,7 +64,7 @@ module Pact
           end
 
           def honours_pacts_from_pact_broker &block
-            create_pact_verification_from_broker &block
+            create_pact_verification_from_broker(&block)
           end
         end
 

--- a/lib/pact/provider/pact_uri.rb
+++ b/lib/pact/provider/pact_uri.rb
@@ -3,7 +3,7 @@ module Pact
     class PactURI
       attr_reader :uri, :options, :metadata
 
-      def initialize (uri, options = nil, metadata = nil)
+      def initialize(uri, options = nil, metadata = nil)
         @uri = uri
         @options = options || {}
         @metadata = metadata || {} # make sure it's not nil if nil is passed in

--- a/lib/pact/provider/state/provider_state.rb
+++ b/lib/pact/provider/state/provider_state.rb
@@ -12,11 +12,11 @@ module Pact
       end
 
       def set_up &block
-        ProviderStates.base_provider_state.register.register_set_up &block
+        ProviderStates.base_provider_state.register.register_set_up(&block)
       end
 
       def tear_down &block
-        ProviderStates.base_provider_state.register_tear_down &block
+        ProviderStates.base_provider_state.register_tear_down(&block)
       end
 
       def provider_states_for name, &block
@@ -60,7 +60,7 @@ module Pact
       end
 
       def self.namespaced_name name, options = {}
-        fullname = options[:for] ? "#{options[:for]}.#{name}" : name
+        options[:for] ? "#{options[:for]}.#{name}" : name
       end
     end
 
@@ -81,11 +81,11 @@ module Pact
 
       dsl do
         def set_up &block
-          self.register_set_up &block
+          self.register_set_up(&block)
         end
 
         def tear_down &block
-          self.register_tear_down &block
+          self.register_tear_down(&block)
         end
 
         def no_op


### PR DESCRIPTION
```
…/configuration/service_provider_dsl.rb:67: warning: `&' interpreted as argument prefix
…/pact_uri.rb:6: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
…/configuration/message_provider_dsl.rb:49: warning: `&' interpreted as argument prefix
…/state/provider_state.rb:15: warning: `&' interpreted as argument prefix
…/state/provider_state.rb:19: warning: `&' interpreted as argument prefix
…/state/provider_state.rb:63: warning: assigned but unused variable - fullname
…/state/provider_state.rb:84: warning: `&' interpreted as argument prefix
…/state/provider_state.rb:88: warning: `&' interpreted as argument prefix
```