### PR TITLE
Update rack-test dependency to allow v2

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_runtime_dependency 'rspec', '~> 3.0'
-  gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 2.0.0'
+  gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 3.0.0'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'


### PR DESCRIPTION
I was adding pact to a newish Rails project and hit an issue with `rack-test` (https://github.com/rack/rack-test/blob/main/History.md) dependency.

```
Bundler could not find compatible versions for gem "rack-test":
  In snapshot (Gemfile.lock):
    rack-test (= 2.0.2)

  In Gemfile:
    rails (~> 6.1) was resolved to 6.1.6.1, which depends on
      actionpack (= 6.1.6.1) was resolved to 6.1.6.1, which depends on
        rack-test (>= 0.6.3)

    pact was resolved to 1.17.0, which depends on
      rack-test (~> 0.6.2)
```

This change updates `ruby-pact` to allow v2 of rack-test


