### PR TITLE
allow running with rack-test 2.X

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   }
 
   gem.add_runtime_dependency 'rspec', '~> 3.0'
-  gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 2.0.0'
+  gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 3.0.0'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'


### PR DESCRIPTION
Relax the restrictions for the version to rack-test to allow to to run against rack-test 2.X.

Running specs locally this does not appear to cause any issues.