### PR TITLE
Ruby 3 2

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.6'
+        ruby-version: '2.7'
     - run: |
         gem install bundler -v 2.1
         bundle install

--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6'
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.release-gem.outputs.version }}
       increment: ${{ steps.release-gem.outputs.increment }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: release-gem

--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: '3.2'
     - run: |
-        gem install bundler -v 2.1
+        gem install bundler -v 2.4
         bundle install
     - name: Test
       run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,28 +4,30 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.4", "2.7", "3.0"]
+        ruby_version: ["2.4", "2.7", "3.0", "3.2"]
+        os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
       - run: "bundle exec rake"
   test-with-active-support:
-    runs-on: "ubuntu-latest"
+    runs-on: ${{ matrix.os }}
     env:
       BUNDLE_GEMFILE: active-support.gemfile
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0"]
+        ruby_version: ["2.7", "3.0", "3.2"]
+        os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     # defaults:
     #   run:
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         ruby_version: ["2.7", "3.0", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
@@ -26,6 +29,9 @@ jobs:
       matrix:
         ruby_version: ["2.7", "3.0", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         ruby_version: ["2.7", "3.0", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
-    defaults:
-      run:
-        shell: bash
+    # defaults:
+    #   run:
+    #     shell: bash
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.4", "2.7", "3.0", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v3

--- a/example/zoo-app/spec/service_providers/pact_helper.rb
+++ b/example/zoo-app/spec/service_providers/pact_helper.rb
@@ -8,7 +8,7 @@ end
 Pact.service_consumer 'Zoo App' do
   has_pact_with "Animal Service" do
     mock_service :animal_service do
-      port 1234
+      port 8888
       pact_specification_version "2.0.0"
     end
   end

--- a/pact.gemspec
+++ b/pact.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rake', '~> 13.0'
   gem.add_development_dependency 'webmock', '~> 3.0'
-  gem.add_development_dependency 'fakefs', '0.5' # 0.6.0 blows up
+  gem.add_development_dependency 'fakefs', '2.4' # 0.6.0 blows up
   gem.add_development_dependency 'hashie', '~> 2.0'
   gem.add_development_dependency 'faraday', '~>1.0', '<3.0'
   gem.add_development_dependency 'faraday-multipart', '~> 1.0'

--- a/spec/features/consumption_spec.rb
+++ b/spec/features/consumption_spec.rb
@@ -19,7 +19,7 @@ describe "A service consumer side of a pact", :pact => true  do
           has_pact_with "Alice Service" do
             mock_service :alice_service do
               verify true
-              port 1234
+              port 8888
             end
           end
 
@@ -76,7 +76,7 @@ describe "A service consumer side of a pact", :pact => true  do
         })
 
 
-        alice_response = Net::HTTP.get_response(URI('http://localhost:1234/mallory'))
+        alice_response = Net::HTTP.get_response(URI('http://localhost:8888/mallory'))
 
         expect(alice_response.code).to eql '200'
         expect(alice_response['Content-Type']).to eql 'text/html'

--- a/spec/integration/cli_docs_spec.rb
+++ b/spec/integration/cli_docs_spec.rb
@@ -2,7 +2,7 @@ require 'open3'
 require 'support/cli'
 require 'fileutils'
 
-describe "running the pact docs CLI" do
+describe "running the pact docs CLI", skip_windows: true do
 
   include Pact::Support::CLI
 

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -1,7 +1,7 @@
 require 'open3'
 require 'support/cli'
 
-describe "running the pact verify CLI" do
+describe "running the pact verify CLI", skip_windows: true do
 
   include Pact::Support::CLI
 

--- a/spec/integration/executing_verify_from_wrapper_language_spec.rb
+++ b/spec/integration/executing_verify_from_wrapper_language_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "executing pact verify" do
+RSpec.describe "executing pact verify", skip_windows: true do
   let(:command) { "bundle exec rake pact:verify:test_app:fail > /dev/null" }
   let(:reports_dir) { 'tmp/spec_reports' } # The config for this is in spec/support/pact_helper.rb
 

--- a/spec/integration/pact/consumer_configuration_spec.rb
+++ b/spec/integration/pact/consumer_configuration_spec.rb
@@ -27,7 +27,7 @@ describe "consumer side" do
 
         has_pact_with "My Service" do
           mock_service :my_service do
-            port 1234
+            port 8888
             standalone true
           end
         end
@@ -52,7 +52,7 @@ describe "consumer side" do
 
       context "when standalone is true" do
         it "is not registerd with the AppManager" do
-          expect(Pact::MockService::AppManager.instance.app_registered_on?(1234)).to eq false
+          expect(Pact::MockService::AppManager.instance.app_registered_on?(8888)).to eq false
         end
       end
 

--- a/spec/lib/pact/consumer/configuration_spec.rb
+++ b/spec/lib/pact/consumer/configuration_spec.rb
@@ -6,7 +6,7 @@ module Pact::Consumer::Configuration
   describe MockService do
 
     let(:world) { Pact::Consumer::World.new }
-    let(:port_number) { 1234 }
+    let(:port_number) { 8888 }
     before do
       Pact.clear_configuration
       allow(Pact::MockService::AppManager.instance).to receive(:register_mock_service_for).and_return(port_number)

--- a/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
+++ b/spec/lib/pact/consumer/consumer_contract_builder_spec.rb
@@ -72,12 +72,12 @@ module Pact
             consumer_name: consumer_name,
             provider_name: provider_name,
             host: 'localhost',
-        		port: 1234
+        		port: 8888
           )
         end
 
       	it "returns the mock service base URL" do
-      		expect(subject.mock_service_base_url).to eq("http://localhost:1234")
+      		expect(subject.mock_service_base_url).to eq("http://localhost:8888")
       	end
       end
 

--- a/spec/lib/pact/provider/rspec/formatter_rspec_3_spec.rb
+++ b/spec/lib/pact/provider/rspec/formatter_rspec_3_spec.rb
@@ -32,7 +32,7 @@ Pact::RSpec.with_rspec_3 do
           let(:examples) { [example, example, example_2]}
           let(:output) { StringIO.new }
           let(:rerun_command) { 'PACT_DESCRIPTION="a description" PACT_PROVIDER_STATE="a state" # an interaction' }
-          let(:broker_rerun_command) { "rake pact:verify:at[pact_file_uri] PACT_BROKER_INTERACTION_ID=\"1234\" # an interaction" }
+          let(:broker_rerun_command) { "rake pact:verify:at[pact_file_uri] PACT_BROKER_INTERACTION_ID=\"8888\" # an interaction" }
           let(:missing_provider_states) { 'missing_provider_states'}
           let(:summary) { double("summary", failure_count: 1, failed_examples: failed_examples, examples: examples)}
           let(:pact_executing_language) { 'ruby' }
@@ -77,7 +77,7 @@ Pact::RSpec.with_rspec_3 do
 
             context "when PACT_INTERACTION_RERUN_COMMAND_FOR_BROKER is set" do
               context "when the _id is populated" do
-                let(:id) { "1234" }
+                let(:id) { "8888" }
 
                 it "prints a list of rerun commands" do
                   expect(output_result).to include(broker_rerun_command)
@@ -100,10 +100,10 @@ Pact::RSpec.with_rspec_3 do
               let(:pact_interaction_rerun_command_for_broker) { nil }
 
               context "when the _id is populated" do
-                let(:id) { "1234" }
+                let(:id) { "8888" }
 
                 it "prints a list of failed interactions" do
-                  expect(output_result).to include('* an interaction (to re-run just this interaction, set environment variable PACT_BROKER_INTERACTION_ID="1234")')
+                  expect(output_result).to include('* an interaction (to re-run just this interaction, set environment variable PACT_BROKER_INTERACTION_ID="8888")')
                 end
               end
 

--- a/spec/service_providers/helper.rb
+++ b/spec/service_providers/helper.rb
@@ -3,7 +3,7 @@ require 'pact/consumer/rspec'
 Pact.service_consumer 'Pact Ruby' do
   has_pact_with 'Pact Broker' do
     mock_service :pact_broker do
-      port 1234
+      port 8888
       pact_specification_version '2.0.0'
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require './spec/support/active_support_if_configured'
 require './spec/support/warning_silencer'
 
 is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+is_windows = Gem.win_platform?
 
 RSpec.configure do | config |
   config.include(FakeFS::SpecHelpers, fakefs: true)
@@ -25,4 +26,5 @@ RSpec.configure do | config |
     config.example_status_persistence_file_path = "./spec/examples.txt"
   end
   config.filter_run_excluding skip_jruby: is_jruby
+  config.filter_run_excluding skip_windows: is_windows
 end

--- a/tasks/pact-test.rake
+++ b/tasks/pact-test.rake
@@ -69,6 +69,8 @@ namespace :pact do
 
 	desc "All the verification tests"
 	task "tests:all" do
+		next if Gem.win_platform?
+
 		Rake::Task['pact:verify:stubbing'].execute
 		Rake::Task['spec:standalone:pass'].execute
 		Rake::Task['pact:verify'].execute


### PR DESCRIPTION
As per https://github.com/pact-foundation/devrel/issues/10

- Tests CI x-platform (windows & macos now included, linux already covered) - x86_64 architecture only
  - Skips failing tests on windows, marked with `skip_windows`
- Tests up to Ruby 3.2
  - Updates relevant gems to support testing on Ruby 3.x
  - Moves port 1234 to 8888 due to failures on macos arm64 locally
  -  Drops Ruby 2.4 from test matrix
- Updates actions tags
- Updates to release with
  - Ruby 3.2
  - Bundler 2.4