### PR TITLE
feat(Link.put!): add a Link.put! method

### DIFF
--- a/lib/pact/hal/link.rb
+++ b/lib/pact/hal/link.rb
@@ -57,6 +57,10 @@ module Pact
         wrap_response(href, @http_client.put(href, payload ? payload.to_json : nil, DEFAULT_POST_HEADERS.merge(headers)))
       end
 
+      def put!(payload = nil, headers = {})
+        put(payload, headers).assert_success!
+      end
+
       def post(payload = nil, headers = {})
         wrap_response(href, @http_client.post(href, payload ? payload.to_json : nil, DEFAULT_POST_HEADERS.merge(headers)))
       end


### PR DESCRIPTION
The `Link` has `get!` and `post!` shorthand methods that do `assert_success!` on the result.
This PR adds missing `put!` shorthand.

Should I also update these lines to use `get!`?
* https://github.com/pact-foundation/pact-ruby/blob/503cedbe9f7505c0be8ff10222967a96a5a9aa6d/lib/pact/pact_broker/fetch_pacts.rb#L75
* https://github.com/pact-foundation/pact-ruby/blob/503cedbe9f7505c0be8ff10222967a96a5a9aa6d/lib/pact/pact_broker/fetch_pacts.rb#L80
* https://github.com/pact-foundation/pact-ruby/blob/503cedbe9f7505c0be8ff10222967a96a5a9aa6d/lib/pact/pact_broker/fetch_pact_uris_for_verification.rb#L57