### PR TITLE
Feat/update fail if no pacts found pr

### DIFF
--- a/example/animal-service/spec/service_consumers/pact_helper.rb
+++ b/example/animal-service/spec/service_consumers/pact_helper.rb
@@ -8,4 +8,11 @@ Pact.service_provider 'Animal Service' do
     pact_uri '../zoo-app/spec/pacts/zoo_app-animal_service.json'
   end
 
+  ## For pact contracts from a Pact Broker
+
+  # honours_pacts_from_pact_broker do
+  #   pact_broker_base_url 'http://localhost:9292'
+  #   # fail_if_no_pacts_found false # defaults to true
+  # end
+
 end

--- a/lib/pact/cli/run_pact_verification.rb
+++ b/lib/pact/cli/run_pact_verification.rb
@@ -72,7 +72,6 @@ module Pact
 
       def run_with_configured_pacts_from_pact_helper
         pact_urls = Pact.provider_world.pact_urls
-        raise "Please configure a pact to verify" if pact_urls.empty?
         Pact::Provider::PactSpecRunner.new(pact_urls, pact_spec_options).run
       end
 

--- a/lib/pact/pact_broker/fetch_pact_uris_for_verification.rb
+++ b/lib/pact/pact_broker/fetch_pact_uris_for_verification.rb
@@ -101,7 +101,7 @@ module Pact
 
       def handling_no_pacts_found
         pacts_found = yield
-        if pacts_found.empty? && options[:fail_if_no_pacts_found] != false
+        if pacts_found.blank? && options[:fail_if_no_pacts_found] != false
           raise "No pacts found to verify"
         else
           pacts_found

--- a/lib/pact/pact_broker/fetch_pact_uris_for_verification.rb
+++ b/lib/pact/pact_broker/fetch_pact_uris_for_verification.rb
@@ -101,11 +101,11 @@ module Pact
 
       def handling_no_pacts_found
         pacts_found = yield
-        if pacts_found.blank? && options[:fail_if_no_pacts_found] != false
-          raise "No pacts found to verify"
-        else
-          pacts_found
+        raise "No pacts found to verify" if pacts_found.blank? && options[:fail_if_no_pacts_found] != false
+        if pacts_found.blank? && options[:fail_if_no_pacts_found] == false
+          Pact.configuration.output_stream.puts "WARN: No pacts found to verify & fail_if_no_pacts_found is set to false."
         end
+        pacts_found
       end
     end
   end

--- a/lib/pact/provider/configuration/pact_verification_from_broker.rb
+++ b/lib/pact/provider/configuration/pact_verification_from_broker.rb
@@ -15,7 +15,7 @@ module Pact
         # in parent scope, it will clash with these ones,
         # so put an underscore in front of the name to be safer.
 
-        attr_accessor :_provider_name, :_pact_broker_base_url, :_consumer_version_tags, :_provider_version_branch, :_provider_version_tags, :_basic_auth_options, :_enable_pending, :_include_wip_pacts_since, :_verbose, :_consumer_version_selectors
+        attr_accessor :_provider_name, :_pact_broker_base_url, :_consumer_version_tags, :_provider_version_branch, :_provider_version_tags, :_basic_auth_options, :_enable_pending, :_include_wip_pacts_since, :_verbose, :_consumer_version_selectors, :_fail_if_no_pacts_found
 
         def initialize(provider_name, provider_version_branch, provider_version_tags)
           @_provider_name = provider_name
@@ -26,6 +26,7 @@ module Pact
           @_enable_pending = false
           @_include_wip_pacts_since = nil
           @_verbose = false
+          @_fail_if_no_pacts_found = true # CLI defaults to false, unfortunately for consistency
         end
 
         dsl do
@@ -44,6 +45,11 @@ module Pact
 
           def enable_pending enable_pending
             self._enable_pending = enable_pending
+          end
+
+          # Underlying code defaults to true if not specified
+          def fail_if_no_pacts_found fail_if_no_pacts_found
+            self._fail_if_no_pacts_found = fail_if_no_pacts_found
           end
 
           def include_wip_pacts_since since
@@ -74,7 +80,7 @@ module Pact
             _provider_version_tags,
             _pact_broker_base_url,
             _basic_auth_options.merge(verbose: _verbose),
-            { include_pending_status: _enable_pending, include_wip_pacts_since: _include_wip_pacts_since }
+            { include_pending_status: _enable_pending, include_wip_pacts_since: _include_wip_pacts_since, fail_if_no_pacts_found: _fail_if_no_pacts_found }
           )
 
           Pact.provider_world.add_pact_uri_source fetch_pacts

--- a/spec/lib/pact/pact_broker/fetch_pact_uris_for_verification_spec.rb
+++ b/spec/lib/pact/pact_broker/fetch_pact_uris_for_verification_spec.rb
@@ -14,7 +14,7 @@ module Pact
         let(:consumer_version_selectors) { [{ tag: "cmaster", latest: true, fallbackTag: 'blah' }] }
         let(:provider_version_branch) { "pbranch" }
         let(:provider_version_tags) { ["pmaster"] }
-
+        
         subject { FetchPactURIsForVerification.call(provider, consumer_version_selectors, provider_version_branch, provider_version_tags, broker_base_url, http_client_options)}
 
         context "when there is an error retrieving the index resource" do
@@ -62,7 +62,7 @@ module Pact
 
           it "calls the old fetch pacts code" do
             expect(FetchPacts).to receive(:call).with(provider, [{ name: "cmaster", all: false, fallback: "blah" }], broker_base_url, http_client_options)
-            subject
+            expect { subject }.to raise_error( "No pacts found to verify" )
           end
         end
       end

--- a/spec/lib/pact/provider/configuration/pact_verification_from_broker_spec.rb
+++ b/spec/lib/pact/provider/configuration/pact_verification_from_broker_spec.rb
@@ -37,7 +37,7 @@ module Pact
 
             let(:fetch_pacts) { double('FetchPacts') }
             let(:basic_auth_opts) { basic_auth_options.merge(verbose: true) }
-            let(:options) { { include_pending_status: true, include_wip_pacts_since: "2020-01-01" }}
+            let(:options) { { fail_if_no_pacts_found: true, include_pending_status: true, include_wip_pacts_since: "2020-01-01" }}
             let(:consumer_version_selectors) { [ { tag: 'master', latest: true }] }
 
             it "creates a instance of Pact::PactBroker::FetchPactURIsForVerification" do
@@ -70,6 +70,7 @@ module Pact
                   anything,
                   anything,
                   {
+                    fail_if_no_pacts_found: true,
                     include_pending_status: true,
                     include_wip_pacts_since: since.xmlschema
                   }


### PR DESCRIPTION
fixes #272 

continuation of #283

Usage

```rb
Pact.service_provider 'your-provider-name' do
  honours_pacts_from_pact_broker do
    pact_broker_base_url '<pact_broker_url>'
    fail_if_no_pacts_found false # defaults to true
  end
end
```