### PR TITLE
refactor(dependencies): Move webrick to be a pure development dependency.

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rspec', '~> 3.0'
   gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 3.0.0'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
-  gem.add_runtime_dependency 'webrick', '~> 1.8'
   gem.add_runtime_dependency "rainbow", '~> 3.1'
 
   gem.add_runtime_dependency 'pact-support', '~> 1.16', '>= 1.16.9'
@@ -45,4 +44,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bump', '~> 0.5'
   gem.add_development_dependency 'pact-message', '~> 0.8'
   gem.add_development_dependency 'rspec-its', '~> 1.3'
+  gem.add_development_dependency 'webrick', '~> 1.8'
 end


### PR DESCRIPTION
Webrick was originally part of the pact application, but is now purely used to support testing.

Also, to quote Jeremy Evans https://github.com/ruby/webrick/issues/145#issuecomment-2359963761

> Webrick has not been part of Ruby since the release of Ruby 3.0, over three years ago. While this repository is under the ruby organization on GitHub, it is no longer considered part of Ruby.
>
> Webrick should not be used in production. It is only still maintained because there are other gems relying it, most of which do so only for testing, and only because it is a pure ruby implementation and it was shipped with Ruby in the past.

As Webrick has recently seen a number of CVEs, pulling Webrick in to other codebases unecessarily causes security related maintenance.

It's still fine for testing.