### PR TITLE
FIX: HTTP_HOST headers.

### DIFF
--- a/lib/pact/provider/request.rb
+++ b/lib/pact/provider/request.rb
@@ -35,7 +35,7 @@ module Pact
 
         def headers
           request_headers = {}
-          request_headers.merge!('HTTP_HOST' => 'localhost') if defined?(Sinatra)
+          request_headers.merge!('HOST' => 'localhost') if defined?(Sinatra)
           return request_headers if expected_request.headers.is_a?(Pact::NullExpectation)
 
           expected_request.headers.each do |key, value|


### PR DESCRIPTION
https://github.com/pact-foundation/pact-ruby/pull/327 is related.

The rspec test for the Zoo App and Animal Service failed because of an incorrect header.

The rspec result is as follows:
```
  2) Verifying a pact between Zoo App and Animal Service Given there is an alligator named Mary a request for an alligator with GET /alligators/Mary returns a response which has a matching body
     Failure/Error: expect(response_body).to match_term expected_response_body, diff_options, example

       Actual: Host not permitted
```

The log is as follows:
```
I, [2025-01-11T08:27:26.148896 #1865]  INFO -- : Sending GET request to path: "/alligators/Mary" with headers: {"HTTP_HTTP_HOST"=>"localhost", "HTTP_ACCEPT"=>"application/json"}, see debug logs for body
```

`HTTP_HTTP_HOST` is not correct, `HTTP_HOST` is currect