### PR TITLE
fix(v2): allow configurable loggers in verifier

### DIFF
--- a/lib/pact/v2/native/logger.rb
+++ b/lib/pact/v2/native/logger.rb
@@ -17,7 +17,7 @@ module Pact
 
         def self.log_to_stdout(log_level)
           raise "invalid log level for PactFfi::FfiLogLevelFilter" unless LOG_LEVELS.key?(log_level)
-          PactFfi::Logger.log_to_stdout(LOG_LEVELS[log_level])
+            PactFfi::Logger.log_to_stdout(LOG_LEVELS[log_level]) unless log_level == :off
         end
       end
     end

--- a/lib/pact/v2/provider/base_verifier.rb
+++ b/lib/pact/v2/provider/base_verifier.rb
@@ -31,7 +31,7 @@ module Pact
           raise ArgumentError, "pact_config must be a subclass of Pact::V2::Provider::PactConfig::Base" unless pact_config.is_a?(::Pact::V2::Provider::PactConfig::Base)
           @pact_config = pact_config
           @mixed_config = mixed_config
-          @logger = Logger.new($stdout)
+          @logger = @pact_config.logger || Logger.new($stdout)
         end
 
         def verify!

--- a/lib/pact/v2/provider/grpc_verifier.rb
+++ b/lib/pact/v2/provider/grpc_verifier.rb
@@ -13,7 +13,7 @@ module Pact
           super
 
           raise ArgumentError, "pact_config must be an instance of Pact::V2::Provider::PactConfig::Grpc" unless pact_config.is_a?(::Pact::V2::Provider::PactConfig::Grpc)
-          @grpc_server = GrufServer.new(host: "127.0.0.1:#{@pact_config.grpc_port}", services: @pact_config.grpc_services)
+          @grpc_server = GrufServer.new(host: "127.0.0.1:#{@pact_config.grpc_port}", services: @pact_config.grpc_services, logger: @pact_config.logger)
         end
 
         private

--- a/lib/pact/v2/provider/http_verifier.rb
+++ b/lib/pact/v2/provider/http_verifier.rb
@@ -13,7 +13,7 @@ module Pact
           super
 
           raise ArgumentError, "pact_config must be an instance of Pact::V2::Provider::PactConfig::Http" unless pact_config.is_a?(::Pact::V2::Provider::PactConfig::Http)
-          @http_server = HttpServer.new(host: "127.0.0.1", port: @pact_config.http_port, app: @pact_config.app)
+          @http_server = HttpServer.new(host: "127.0.0.1", port: @pact_config.http_port, app: @pact_config.app, logger: @pact_config.logger)
         end
 
         private

--- a/lib/pact/v2/provider/message_provider_servlet.rb
+++ b/lib/pact/v2/provider/message_provider_servlet.rb
@@ -12,12 +12,12 @@ module Pact
         CONTENT_TYPE_PROTO = "application/protobuf"
         METADATA_HEADER = "pact-message-metadata"
 
-        def initialize(logger: Logger.new($stdout))
+        def initialize(logger: nil)
           super(build_proc)
 
           @message_handlers = {}
 
-          @logger = logger
+          @logger = logger || Logger.new($stdout)
         end
 
         def add_message_handler(name, &block)

--- a/lib/pact/v2/provider/pact_broker_proxy_runner.rb
+++ b/lib/pact/v2/provider/pact_broker_proxy_runner.rb
@@ -35,7 +35,10 @@ module Pact
             require 'rackup/handler/webrick'
             handler = Class.new(Rackup::Handler::WEBrick)
           end
-          @server = WEBrick::HTTPServer.new({BindAddress: @host, Port: @port}, WEBrick::Config::HTTP)
+          @server = WEBrick::HTTPServer.new(
+            { BindAddress: @host, Port: @port, Logger: @logger, AccessLog: [] },
+            WEBrick::Config::HTTP
+            )
           @server.mount("/", handler, PactBrokerProxy.new(
             nil,
             backend: @pact_broker_host,

--- a/lib/pact/v2/provider/pact_config/base.rb
+++ b/lib/pact/v2/provider/pact_config/base.rb
@@ -8,13 +8,14 @@ module Pact
           attr_reader :provider_name, :provider_version, :log_level, :provider_setup_server, :provider_setup_port, :pact_proxy_port,
             :consumer_branch, :consumer_version, :consumer_name, :broker_url, :broker_username, :broker_password, :verify_only, :pact_dir,
             :pact_uri, :provider_version_branch, :provider_version_tags, :consumer_version_selectors, :enable_pending, :include_wip_pacts_since,
-            :fail_if_no_pacts_found, :provider_build_uri, :broker_token, :consumer_version_tags, :publish_verification_results
+            :fail_if_no_pacts_found, :provider_build_uri, :broker_token, :consumer_version_tags, :publish_verification_results, :logger
 
 
           def initialize(provider_name:, opts: {})
             @provider_name = provider_name
             @log_level = opts[:log_level] || :info
             @pact_dir = opts[:pact_dir] || nil
+            @logger = opts[:logger] || nil
             @provider_setup_port = opts[:provider_setup_port] || 9001
             @pact_proxy_port = opts[:provider_setup_port] || 9002
             @pact_uri = ENV.fetch("PACT_URL", nil) || opts.fetch(:pact_uri, nil)
@@ -37,14 +38,15 @@ module Pact
             @broker_token = ENV.fetch("PACT_BROKER_TOKEN", nil) || opts.fetch(:broker_token, nil)
             @verify_only = [ENV.fetch("PACT_CONSUMER_FULL_NAME", nil)].compact || opts.fetch(:verify_only, [])
 
-            @provider_setup_server = opts[:provider_setup_server] || ProviderServerRunner.new(port: @provider_setup_port)
+            @provider_setup_server = opts[:provider_setup_server] || ProviderServerRunner.new(port: @provider_setup_port, logger: @logger)
             if @broker_url.present?
               @pact_proxy_server = PactBrokerProxyRunner.new(
                 port: @pact_proxy_port,
                 pact_broker_host: @broker_url,
                 pact_broker_user: @broker_username,
                 pact_broker_password: @broker_password,
-                pact_broker_token: @broker_token
+                pact_broker_token: @broker_token,
+                logger: @logger
               )
             end
           end

--- a/lib/pact/v2/provider/pact_config/mixed.rb
+++ b/lib/pact/v2/provider/pact_config/mixed.rb
@@ -10,14 +10,15 @@ module Pact
 
           def initialize(provider_name:, opts: {})
             super
-            @provider_setup_server = ProviderServerRunner.new(port: @provider_setup_port)
+            @provider_setup_server = ProviderServerRunner.new(port: @provider_setup_port, logger: @logger)
             if @broker_url.present?
               @pact_proxy_server = PactBrokerProxyRunner.new(
                 port: @pact_proxy_port,
                 pact_broker_host: @broker_url,
                 pact_broker_user: @broker_username,
                 pact_broker_password: @broker_password,
-                pact_broker_token: @broker_token
+                pact_broker_token: @broker_token,
+                logger: @logger
               )
             end
             @http_config = opts[:http] ? Http.new(provider_name: provider_name, opts: opts[:http].merge(provider_setup_server: provider_setup_server, pact_proxy_server: @pact_proxy_server)) : nil

--- a/lib/pact/v2/provider/provider_server_runner.rb
+++ b/lib/pact/v2/provider/provider_server_runner.rb
@@ -34,7 +34,10 @@ module Pact
         def start
           raise "server already running, stop server before starting new one" if @thread
 
-          @server = WEBrick::HTTPServer.new({BindAddress: @host, Port: @port}, WEBrick::Config::HTTP)
+            @server = WEBrick::HTTPServer.new(
+            { BindAddress: @host, Port: @port, Logger: @logger, AccessLog: [] },
+            WEBrick::Config::HTTP
+            )
           @server.mount(SETUP_PROVIDER_STATE_PATH, @state_servlet)
           @server.mount(VERIFY_MESSAGE_PATH, @message_servlet)
 

--- a/lib/pact/v2/provider/provider_state_servlet.rb
+++ b/lib/pact/v2/provider/provider_state_servlet.rb
@@ -8,10 +8,10 @@ module Pact
       class ProviderStateServlet < WEBrick::HTTPServlet::ProcHandler
         attr_reader :logger
 
-        def initialize(logger: Logger.new($stdout))
+        def initialize(logger: nil)
           super(build_proc)
 
-          @logger = logger
+          @logger = logger || Logger.new($stdout)
 
           @provider_setup_states = {}
           @provider_teardown_states = {}


### PR DESCRIPTION
allow passing of the logger through to the respective apps, in order to allow configurability as to where they go (stdout, file etc)

stops rust core logging being set, if log level is none