### PR TITLE
Remove jsonpath/string_pattern dependencies (unused in this gem)

### DIFF
--- a/pact.gemspec
+++ b/pact.gemspec
@@ -80,7 +80,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rack-test', '>= 0.6.3', '< 3.0.0'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency "rainbow", '~> 3.1'
-  gem.add_runtime_dependency 'string_pattern', '~> 2.0'
 
   gem.add_runtime_dependency "pact-support" , "~> 1.21", ">=1.21.2"
   gem.add_runtime_dependency 'pact-mock_service', '~> 3.0', '>= 3.3.1'


### PR DESCRIPTION
## Overview

I was following a dependency trail and found that this gem no longer uses the JsonPath or StringPattern libraries. 
