### PR TITLE
fix: support scalar request and response bodies in InteractionContents

### DIFF
--- a/lib/pact/consumer/http_interaction_builder.rb
+++ b/lib/pact/consumer/http_interaction_builder.rb
@@ -82,7 +82,7 @@ module Pact
         end
 
         if body
-          PactFfi.with_body(pact_interaction, interaction_part, "application/json", format_value(InteractionContents.basic(body)))
+          PactFfi.with_body(pact_interaction, interaction_part, "application/json", format_value(InteractionContents.basic(body).value))
         end
 
         self
@@ -97,7 +97,7 @@ module Pact
         end
 
         if body
-          PactFfi.with_body(pact_interaction, interaction_part, "application/json", format_value(InteractionContents.basic(body)))
+          PactFfi.with_body(pact_interaction, interaction_part, "application/json", format_value(InteractionContents.basic(body).value))
         end
 
         self

--- a/lib/pact/consumer/interaction_contents.rb
+++ b/lib/pact/consumer/interaction_contents.rb
@@ -17,36 +17,38 @@ module Pact
       end
 
       def initialize(contents_hash, format)
-        init_hash(contents_hash, format).each_pair { |k, v| self[k] = v }
+        serialized = init_hash(contents_hash, format)
+        # A scalar body (plain string, integer, etc.) serializes to a non-Hash
+        # value that cannot be merged pair by pair; expose it via #value instead.
+        if serialized.is_a?(Hash)
+          serialized.each_pair { |k, v| self[k] = v }
+        else
+          @value = serialized
+        end
         @format = format
+      end
+
+      def value
+        defined?(@value) ? @value : self
       end
 
       private
 
       def serialize(hash, format)
         # serialize recursively
-        return hash if hash.is_a?(String)
+        if hash.is_a?(Pact::Matchers::Base) || hash.is_a?(Pact::Generators::Base)
+          return hash.as_basic if format == :basic
+          return hash.as_plugin if format == :plugin
+        end
 
-        if hash.is_a?(Pact::Matchers::Base)
-          return hash.as_basic if format == :basic
-          return hash.as_plugin if format == :plugin
-        end
-        if hash.is_a?(Pact::Generators::Base)
-          return hash.as_basic if format == :basic
-          return hash.as_plugin if format == :plugin
-        end
+        return hash.map { |value| serialize(value, format) } if hash.is_a?(Array)
+
+        # A value that is not a collection or a matcher/generator has nothing to
+        # recurse into, so return it unchanged (string, integer, boolean, nil, ...).
+        return hash unless hash.is_a?(Hash)
+
         hash.each_pair do |key, value|
-          next serialize(value, format) if value.is_a?(Hash)
-          next hash[key] = value.map { |v| serialize(v, format) } if value.is_a?(Array)
-
-          if value.is_a?(Pact::Matchers::Base)
-            hash[key] = value.as_basic if format == :basic
-            hash[key] = value.as_plugin if format == :plugin
-          end
-          if value.is_a?(Pact::Generators::Base)
-            hash[key] = value.as_basic if format == :basic
-            hash[key] = value.as_plugin if format == :plugin
-          end
+          hash[key] = serialize(value, format)
         end
 
         hash

--- a/spec/lib/consumer/interaction_contents_spec.rb
+++ b/spec/lib/consumer/interaction_contents_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe Pact::Consumer::InteractionContents do
         .to eq('{"str":{"pact:matcher:type":"regex","value":"str","regex":"(?-mix:.*)"},"bool":{"pact:matcher:type":"boolean","value":true},"num":{"pact:matcher:type":"number","value":1},"nested":{"pact:matcher:type":"type","value":[{"a":1,"b":"2"}],"min":1}}') # rubocop:disable Layout/LineLength
     end
   end
+
+  context 'with a scalar body' do
+    it 'returns a plain string unchanged' do
+      expect(described_class.basic('plain text').value).to eq('plain text')
+    end
+
+    it 'returns an integer unchanged' do
+      expect(described_class.basic(42).value).to eq(42)
+    end
+  end
+
+  context 'with an array of scalars nested in a hash' do
+    it 'serializes without raising' do
+      expect(described_class.basic({ some_array: [42] }).to_json).to eq('{"some_array":[42]}')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`InteractionContents` assumed every body was a hash, so a plain-string or integer body (or an array of scalars nested in a hash, e.g. `{some_array: [42]}`) raised `NoMethodError: undefined method 'each_pair'` instead of serializing. `serialize` now returns non-collection values unchanged and a scalar body is exposed through `#value` for `with_request`/`will_respond_with` to pass to the FFI core.

Added specs covering a plain string body, an integer body, and an array of scalars nested in a hash.

Fixes #402