### PR TITLE
Docs: Fix typo on dirname in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For each type of interaction (due to their specific features), a separate versio
 
 Place your consumer tests under
 
-`spec/pact/provider/**`
+`spec/pact/providers/**`
 
 **it's not an error: consumer tests contain `providers` subdirectory (because we're testing against different providers)**
 


### PR DESCRIPTION
I believe this should be `spec/pact/providers/**` instead of `spec/pact/provider/**` as the README.md file states.

Not having it in `spec/pact/providers/**`` will cause the consumer tests to not run with a confusing error message like:
```
NoMethodError:
  undefined method 'has_http_pact_between' for class RSpec::ExampleGroups...
```